### PR TITLE
feat: Add text substitution feature

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -20,11 +20,14 @@ Examples:
   ppg generate              # Generate individual markdown files
   ppg g                     # Same as above (shorthand)
   ppg generate --no-mask    # Generate files without masking sensitive data
+  ppg generate --replace "old1=new1,old2=new2"  # Add text replacements
   ppg all                   # Generate a single all-in-one file
+  ppg all --config config.ini # Load configurations from config file
 
 Environment Variables:
   PPG_OUTPUT_DIR           # Custom output directory (default: ppg_generated)
   PPG_OUTPUT_FILE          # Custom output filename (default: ppg_created_all.md.txt)
+  PPG_REPLACE              # Comma-separated string replacements (old=new,...)
 
 For more information, visit: https://github.com/qrtt1/project-prompt-generator
 """
@@ -44,6 +47,16 @@ For more information, visit: https://github.com/qrtt1/project-prompt-generator
             "default": [],
             "metavar": "REGEX",
             "help": "Add custom regex patterns to mask sensitive data"
+        },
+        "--replace": {
+            "action": "store",
+            "default": None,
+            "help": "Comma-separated string replacements (old=new,...)"
+        },
+        "--config": {
+            "action": "store",
+            "default": None,
+            "help": "Path to a configuration file (ini or json)"
         }
     }
 
@@ -80,6 +93,52 @@ Output location can be customized with the PPG_OUTPUT_FILE environment variable.
     # Parse arguments
     args = parser.parse_args()
 
+    # Load configurations from file if specified
+    config = {}
+    if args.config:
+        import configparser
+        import json
+
+        try:
+            with open(args.config, 'r') as f:
+                if args.config.endswith('.ini'):
+                    config_parser = configparser.ConfigParser()
+                    config_parser.read(args.config)
+                    config = config_parser['replace'] if 'replace' in config_parser else {}
+                elif args.config.endswith('.json'):
+                    config = json.load(f)['replace']
+        except Exception as e:
+            print(f"Error loading config file: {e}")
+            sys.exit(1)
+
+    # Override configurations with command-line arguments
+    replace_args = {}
+    if args.replace:
+        replacements = args.replace.split(',')
+        for replacement in replacements:
+            if '=' in replacement:
+                old, new = replacement.split('=', 1)
+                replace_args[old] = new
+
+    # Override configurations with environment variables
+    env_replace = os.environ.get("PPG_REPLACE")
+    env_replace_args = {}
+    if env_replace:
+        replacements = env_replace.split(',')
+        for replacement in replacements:
+            if '=' in replacement:
+                old, new = replacement.split('=', 1)
+                env_replace_args[old] = new
+
+    # Merge configurations with priority: command-line > environment > config file
+    final_replace = {}
+    if config:
+        final_replace.update(config)
+    if env_replace_args:
+        final_replace.update(env_replace_args)
+    if replace_args:
+        final_replace.update(replace_args)
+
     # Show current environment configuration if requested
     output_dir = os.environ.get("PPG_OUTPUT_DIR", "ppg_generated")
     output_file = os.environ.get("PPG_OUTPUT_FILE", "ppg_created_all.md.txt")
@@ -91,10 +150,10 @@ Output location can be customized with the PPG_OUTPUT_FILE environment variable.
 
     if args.command in ["generate", "g", "gen"]:
         print(f"Using output directory: {output_dir}")
-        generate_individual_files(args.no_mask, args.add_pattern)
+        generate_individual_files(args.no_mask, args.add_pattern, final_replace)
     elif args.command in ["generate_all_in_one", "a", "all"]:
         print(f"Using output file: {output_file}")
-        generate_single_file(args.no_mask, args.add_pattern)
+        generate_single_file(args.no_mask, args.add_pattern, final_replace)
 
 
 if __name__ == "__main__":

--- a/prompts/file_processor.py
+++ b/prompts/file_processor.py
@@ -81,7 +81,7 @@ def get_files_to_process(project_root, output_dir, output_file="ppg_created_all.
     return sorted(files_to_process, key=lambda p: os.path.relpath(p, project_root))
 
 
-def process_file(file_full_path, project_root, masker, no_mask):
+def process_file(file_full_path, project_root, masker, no_mask, replace=None):
     """
     Process a single file and generate its markdown representation
 
@@ -90,6 +90,7 @@ def process_file(file_full_path, project_root, masker, no_mask):
         project_root: Root directory of the project
         masker: SensitiveMasker instance
         no_mask: Flag to disable masking
+        replace (dict, optional): Dictionary of string replacements. Defaults to None.
 
     Returns:
         Markdown content as a string, or None if processing failed
@@ -102,6 +103,11 @@ def process_file(file_full_path, project_root, masker, no_mask):
     except Exception as e:
         print(f"Skipping {rel_path}: {e}")
         return None
+
+    # Apply string replacements if specified
+    if replace:
+        for old, new in replace.items():
+            file_content = file_content.replace(old, new)
 
     # Mask sensitive data by default unless disabled
     if masker and not no_mask:

--- a/prompts/generator.py
+++ b/prompts/generator.py
@@ -72,7 +72,7 @@ def ensure_directory_exists(path):
         print(f"Created directory: {directory}")
 
 
-def generate_individual_files(no_mask, add_pattern):
+def generate_individual_files(no_mask, add_pattern, replace=None):
     """Generate individual markdown files in the output directory"""
     # Define the project root as the current working directory
     project_root = os.getcwd()
@@ -100,7 +100,7 @@ def generate_individual_files(no_mask, add_pattern):
     # Process each file
     for file_full_path in files_to_process:
         rel_path = os.path.relpath(file_full_path, project_root)
-        markdown_content = process_file(file_full_path, project_root, masker, no_mask)
+        markdown_content = process_file(file_full_path, project_root, masker, no_mask, replace)
         if not markdown_content:
             continue
 
@@ -128,7 +128,7 @@ def generate_individual_files(no_mask, add_pattern):
     print(f"Generated {len(markdown_files_info)} individual markdown files in {OUTPUT_DIR}/")
 
 
-def generate_single_file(no_mask, add_pattern):
+def generate_single_file(no_mask, add_pattern, replace=None):
     """Generate a single markdown file with all content"""
     project_root = os.getcwd()
 
@@ -145,7 +145,7 @@ def generate_single_file(no_mask, add_pattern):
     # Process each file
     for file_full_path in files_to_process:
         rel_path = os.path.relpath(file_full_path, project_root)
-        markdown_content = process_file(file_full_path, project_root, masker, no_mask)
+        markdown_content = process_file(file_full_path, project_root, masker, no_mask, replace)
         if not markdown_content:
             continue
 
@@ -178,7 +178,7 @@ def generate_single_file(no_mask, add_pattern):
         # Write content for each file
         for seq, original, md_filename, rel_path in markdown_files_info:
             file_path = os.path.join(project_root, rel_path)
-            markdown_content = process_file(file_path, project_root, masker, no_mask)
+            markdown_content = process_file(file_path, project_root, masker, no_mask, replace)
             if not markdown_content:
                 continue
 

--- a/tests/test_file_processor.py
+++ b/tests/test_file_processor.py
@@ -1,0 +1,104 @@
+"""
+Tests for the file_processor module, specifically the text replacement feature.
+"""
+
+import pytest
+from prompts.file_processor import process_file
+from prompts.sensitive_masker import SensitiveMasker
+import os
+import tempfile
+
+# Mock masker for testing purposes
+MASKER = SensitiveMasker()
+
+
+@pytest.fixture(scope="function")
+def temp_project_root():
+    """
+    Fixture to create a temporary project root directory.
+    This will be cleaned up after each test function.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield tmpdir
+
+
+def create_dummy_file(project_root, filepath, content):
+    """Creates a dummy file for testing within the temporary directory."""
+    full_path = os.path.join(project_root, filepath)
+    os.makedirs(os.path.dirname(full_path), exist_ok=True)
+    with open(full_path, "w", encoding="utf-8") as f:
+        f.write(content)
+    return full_path
+
+
+def test_text_replacement(temp_project_root):
+    # Create a dummy file with some content
+    file_content = "This is a test file.\nReplace this word."
+    filepath = create_dummy_file(temp_project_root, "test_file.txt", file_content)
+
+    # Define replacements
+    replace = {"test": "success", "word": "string"}
+
+    # Process the file with replacements
+    markdown_content = process_file(filepath, temp_project_root, MASKER, False, replace)
+
+    # Assert that the replacements were made
+    assert "This is a success file." in markdown_content
+    assert "Replace this string." in markdown_content
+
+
+def test_text_replacement_no_replace(temp_project_root):
+    # Test when no replacements are provided
+    file_content = "This is a test file."
+    filepath = create_dummy_file(temp_project_root, "test_file.txt", file_content)
+
+    # Process the file without replacements
+    markdown_content = process_file(filepath, temp_project_root, MASKER, False)
+
+    # Assert that the content remains unchanged
+    assert "This is a test file." in markdown_content
+
+
+def test_text_replacement_empty_file(temp_project_root):
+    # Test with an empty file
+    filepath = create_dummy_file(temp_project_root, "test_file.txt", "")
+
+    # Define replacements (though they shouldn't have any effect)
+    replace = {"test": "success"}
+
+    # Process the empty file
+    markdown_content = process_file(filepath, temp_project_root, MASKER, False, replace)
+
+    # Assert that the markdown content for an empty file is still generated
+    assert "## file description" in markdown_content
+    assert "filename: test_file.txt" in markdown_content
+
+
+def test_text_replacement_special_chars(temp_project_root):
+    # Test replacement with special characters in old/new strings
+    file_content = "Special chars: $, ^, *, +, ?, ., \\"
+    filepath = create_dummy_file(temp_project_root, "test_file.txt", file_content)
+
+    # Define replacements with special chars
+    replace = {"$": "USD", "^": "**", "\\": "/"}
+
+    # Process the file
+    markdown_content = process_file(filepath, temp_project_root, MASKER, False, replace)
+
+    # Assert that special characters are handled correctly
+    assert "Special chars: USD, **, *, +, ?, ., /" in markdown_content
+
+
+def test_text_replacement_multiple_occurrences(temp_project_root):
+    # Test replacement with multiple occurrences of the same string
+    file_content = "test test test"
+    filepath = create_dummy_file(temp_project_root, "test_file.txt", file_content)
+
+    # Define replacement
+    replace = {"test": "success"}
+
+    # Process the file
+    markdown_content = process_file(filepath, temp_project_root, MASKER, False, replace)
+
+    # Assert that all occurrences are replaced
+    assert "success success success" in markdown_content


### PR DESCRIPTION
This commit introduces a new feature that allows users to perform text substitutions within project files during markdown conversion.

The following changes were made:

- Added `--replace` and `--config` arguments to the CLI for specifying replacements.
- Implemented logic to load replacements from command line, environment variables (PPG_REPLACE), and configuration files (ini/json).
- Modified `process_file` function in `file_processor.py` to apply the specified replacements.
- Added new tests in `test_file_processor.py` to verify the text substitution functionality.

This feature enables users to customize the generated markdown by replacing specific strings, enhancing flexibility and control over the output.